### PR TITLE
fixed q doesnt exit

### DIFF
--- a/src/dAngr/cli/command_line_debugger.py
+++ b/src/dAngr/cli/command_line_debugger.py
@@ -121,7 +121,7 @@ class CommandLineDebugger(Debugger,StepHandler):
         try:
             if not command:
                 return True
-            elif command == "exit":
+            elif command in ("exit", "q"):
                 return False
             # command = command.strip()
             script = parse_input(command, debugger=self)


### PR DESCRIPTION
shorthand for "exit" ("q") didn't exit when used.